### PR TITLE
Added matchers for empty and truthy

### DIFF
--- a/src/matchers.js
+++ b/src/matchers.js
@@ -147,6 +147,19 @@ beforeEach(function() {
         return e instanceof klass;
       }
       return false;
+    },
+
+    toBeTrue: function(){
+      var not = this.isNot ? " NOT" : "";
+      var actual = this.actual;
+      this.message = function() {
+        return 'Expected ' + actual + not + ' to be a thruthy value.';
+      }
+      if(!!this.actual){
+        return true;
+      } else {
+        return false;
+      }
     }
 
   });

--- a/src/matchers.js
+++ b/src/matchers.js
@@ -160,6 +160,10 @@ beforeEach(function() {
       } else {
         return false;
       }
+    },
+
+    toBeEmpty: function(){
+      return this.actual.length === 0;
     }
 
   });

--- a/test/matchers-spec.js
+++ b/test/matchers-spec.js
@@ -437,4 +437,26 @@ require(['../src/matchers'], function() {
 
   });
 
+  describe('toBeTrue', function(){
+    describe('matches', function(){
+      it('should pass for true', function(){
+        expect(true).toBeTrue();
+      });
+      it('should pass for char', function(){
+        expect('x').toBeTrue();
+      });
+      it('should pass for int', function(){
+        expect(1).toBeTrue();
+      });
+    });
+    describe('non-matches', function(){
+      it('should say false is NOT a truthy value', function(){
+        expect(false).not.toBeTrue();
+      });
+      it('should say 0 is NOT a thruthy value', function(){
+        expect(0).not.toBeTrue();
+      });
+    });
+  });
+
 });

--- a/test/matchers-spec.js
+++ b/test/matchers-spec.js
@@ -459,4 +459,22 @@ require(['../src/matchers'], function() {
     });
   });
 
+  describe('toBeEmpty', function(){
+    describe('matches', function(){
+      it('should pass for ""', function(){
+        expect("").toBeEmpty();
+      });
+      it('should pass for []', function(){
+        expect([]).toBeEmpty();
+      });
+    });
+    describe('non-matches', function(){
+      it('should say NOT empty for "abc"', function(){
+        expect('abc').not.toBeEmpty();
+      });
+      it('should say NOT empty for [1,2,3]', function(){
+        expect([1,2,3]).not.toBeEmpty();
+      });
+    });
+  });
 });


### PR DESCRIPTION
The goal was to make matching values which evaluate to true more readable, also making the failure message sane so you don't get a "expected false to be true" but a "expected 0 to be truthy".

Also added a matcher to check for emptiness of array or string, to me 
expect([]).toBeEmpty() reads better than expect([]).toHaveLength(0).
